### PR TITLE
Fix isElectionExpired database lookup

### DIFF
--- a/util/housekeeping.js
+++ b/util/housekeeping.js
@@ -38,11 +38,16 @@ module.exports.isElectionEnded = async (electionId) => {
 module.exports.isElectionExpired = async (electionId) => {
   if (!electionId) return false;
 
-  const foundElection = Election.findByPk(electionId);
+  try {
+    const foundElection = await Election.findByPk(electionId);
 
-  if (!foundElection) return false;
+    if (!foundElection) return false;
 
-  return foundElection.expiration < new Date();
+    return foundElection.expiration < new Date();
+  } catch (err) {
+    console.error("isElectionExpired error:", err);
+    return false;
+  }
 };
 
 module.exports.expireElections = () => {


### PR DESCRIPTION
## Summary
- handle potential errors when checking election expiry
- await election fetch in `isElectionExpired`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6872c07f440c8321b618e713c61ebce9