### PR TITLE
Fix typo in login controller catch block

### DIFF
--- a/controllers/login.js
+++ b/controllers/login.js
@@ -270,7 +270,7 @@ exports.enable2FA = (req, res, next) => {
         })
         .catch((err) => next(err));
     })
-    .catch((err) => nexy(err));
+    .catch((err) => next(err));
 };
 
 exports.getGenerate2FAVerification = (req, res, next) => {


### PR DESCRIPTION
## Summary
- fix typo from `nexy` to `next` in login 2FA flow

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6872d8f69f888321b44f3b72f7b505e9