### PR TITLE
Fix election variable typo

### DIFF
--- a/controllers/election.js
+++ b/controllers/election.js
@@ -200,7 +200,7 @@ module.exports.postUpdateElection = (req, res, next) => {
         foundElection.description = req.body.description;
 
       if (req.body.electionType)
-        foundELection.electionType = req.body.electionType;
+        foundElection.electionType = req.body.electionType;
       if (req.body.groupId || req.body.groupId === null)
         foundElection.groupId = req.body.groupId;
       if (req.body.categoryId || req.body.groupId === null)


### PR DESCRIPTION
## Summary
- correct typo in election update controller

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6872d8f5427c83219043e026fa02c71e